### PR TITLE
explicitly declare the dep for string

### DIFF
--- a/misc/libsuc/GStats.h
+++ b/misc/libsuc/GStats.h
@@ -45,6 +45,7 @@
 #include <list>
 #include <stdarg.h>
 #include <vector>
+#include <string>
 
 #include "callback.h"
 #include "nanassert.h"

--- a/simu/libcore/GMemorySystem.h
+++ b/simu/libcore/GMemorySystem.h
@@ -40,7 +40,7 @@
 #include <strings.h>
 
 #include <vector>
-
+#include <string>
 #include "estl.h"
 #include "nanassert.h"
 


### PR DESCRIPTION
I try to build it on my [wsl archlinux](https://github.com/yuk7/ArchWSL), I have encountered some minor errors while compiling because the #include<string> is not explicitly declared. 
I believe that's because my building toolchain is slightly stricter than the vm and it is a good idea to make the dependency clear.
 