### PR TITLE
Add default.nix & BUILDING doc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,25 @@
+# Building esesc
+
+## Linux
+
+### Debian
+Install the necessary dependencies.
+```bash
+sudo apt install ncurses pixman-1 bison flex \
+                 cmake libpixman-1-dev ncurses
+
+```
+
+## Nix
+
+[Nix](https://nixos.org/) is a way to create reproducible builds
+and deployments.
+
+> You can use Nix on any Linux/Darwin distribution or even it's own
+> distribution NixOS
+
+A build (_default.nix_) is included, and you can easily install **esesc**
+via running `nix build` within the directory or install it by doing:
+```bash
+nix run -f https://github.com/masc-ucsc/esesc/archive/master.tar.gz --command esesc
+```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,35 @@
+with import <nixpkgs> { };
+stdenv.mkDerivation {
+  name = "esesc";
+  src = fetchFromGitHub {
+    owner = "masc-ucsc";
+    repo = "esesc";
+    rev = "2d18b03c23057a3b21cf166f788e8e57a28f5745";
+    sha256 = "sha256:0zvp080x7q5aid59li4fjqaq7g8nlm7j0srmnyrqbkqryh8l4phh";
+  };
+
+  # build inputs only for building (not runtime)
+  nativeBuildInputs = [ cmake bison flex pkg-config ];
+
+  buildInputs = [ ncurses xorg.libX11 zlib python27 perl pixman glib ];
+
+  postPatch = ''
+    		# We want to replace all the hardcoded /bin/ls
+    		FILES_WITH_BIN_LS="
+    			emul/qemu_riscv/Makefile.target
+    			emul/qemu_riscv/qemu-doc.texi
+    			emul/qemu_mipsr6/Makefile.target
+    			emul/qemu_mipsr6/qemu-doc.texi
+    		"
+    	    for f in $FILES_WITH_BIN_LS
+    	    do
+    	    	# I have no clue why qemu tries to do `@cp /bin/ls $@`
+          		substituteInPlace $f --replace "/bin/ls" "${coreutils}/bin/ls"
+        	done
+    	'';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp main/esesc $out/bin
+  '';
+}


### PR DESCRIPTION
Add ability to build esesc via nix & start a BUILDING.md file to document other means.

```
❯ nix-build
/nix/store/1x1wiz5mcr8b1zxl8ga7lvnvrxd74sky-esesc

❯ ls -l /nix/store/1x1wiz5mcr8b1zxl8ga7lvnvrxd74sky-esesc/bin/esesc

.r-xr-xr-x 4.9M fmzakari 31 Dec  1969 /nix/store/1x1wiz5mcr8b1zxl8ga7lvnvrxd74sky-esesc/bin/esesc
❯ ldd /nix/store/1x1wiz5mcr8b1zxl8ga7lvnvrxd74sky-esesc/bin/esesc

	linux-vdso.so.1 (0x00007ffda1b5f000)
	/lib/x86_64-linux-gnu/libnss_cache.so.2 (0x00007f17becc4000)
	libncursesw.so.6 => /nix/store/pgx1xxgx503z3s88pfgmf5gb2zbypgy8-ncurses-6.2/lib/libncursesw.so.6 (0x00007f17bec50000)
	librt.so.1 => /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/librt.so.1 (0x00007f17bec46000)
	libz.so.1 => /nix/store/7nwhl76vj9r5kfd1af9xa2cqdridblv6-zlib-1.2.11/lib/libz.so.1 (0x00007f17bec29000)
	libpthread.so.0 => /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/libpthread.so.0 (0x00007f17bec08000)
	libglib-2.0.so.0 => /nix/store/0ds5gvys9awz8ab2mybyfhy7532yrhxa-glib-2.66.2/lib/libglib-2.0.so.0 (0x00007f17bead6000)
	libm.so.6 => /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/libm.so.6 (0x00007f17be993000)
	libstdc++.so.6 => /nix/store/51hq0xxp9nng3xxfz7dpkhb9lzy7sz84-gcc-9.3.0-lib/lib/libstdc++.so.6 (0x00007f17be7b2000)
	libgcc_s.so.1 => /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/libgcc_s.so.1 (0x00007f17be798000)
	libc.so.6 => /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/libc.so.6 (0x00007f17be5d7000)
	/nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f17c1123000)
	libpcre.so.1 => /nix/store/qb4rmys9h9abdh104jjflfj8hscm9n9d-pcre-8.44/lib/libpcre.so.1 (0x00007f17be563000)
```